### PR TITLE
Fix no such file or directory error in generate_symmetric_keys

### DIFF
--- a/lib/symmetric_encryption/symmetric_encryption.rb
+++ b/lib/symmetric_encryption/symmetric_encryption.rb
@@ -134,6 +134,7 @@ module SymmetricEncryption
   #    Default: Rails.env
   def self.load!(filename=nil, environment=nil)
     config = read_config(filename, environment)
+    generate_symmetric_key_files
 
     # Check for hard coded key, iv and cipher
     if config[:key]


### PR DESCRIPTION
Following the Readme step by step the following command fails:

```
machine$ RAILS_ENV=production bin/rake symmetric_encryption:generate_symmetric_keys
```

```
rake aborted!
No such file or directory - /tmp/rails/enerweb.key
```

After inspecting the source code I found that the call to `generate_symmetric_key_files` in symmetric_encryption.rb was missing. Adding this on 137 solves the problem.
