### PR TITLE
Define encrypted ActiveRecord methods inside a module, so we can use super

### DIFF
--- a/lib/symmetric_encryption/extensions/active_record/base.rb
+++ b/lib/symmetric_encryption/extensions/active_record/base.rb
@@ -46,9 +46,16 @@ module ActiveRecord #:nodoc:
         compress  = options.fetch(:compress, false)
         marshal   = options.fetch(:marshal, false)
 
+        if const_defined?(:EncryptedAttributes, _search_ancestors = false)
+          mod = const_get(:EncryptedAttributes)
+        else
+          mod = const_set(:EncryptedAttributes, Module.new)
+          include mod
+        end
+
         params.each do |attribute|
           # Generate unencrypted attribute with getter and setter
-          class_eval(<<-UNENCRYPTED, __FILE__, __LINE__ + 1)
+          mod.module_eval(<<-UNENCRYPTED, __FILE__, __LINE__ + 1)
             # Returns the decrypted value for the encrypted attribute
             # The decrypted value is cached and is only decrypted if the encrypted value has changed
             # If this method is not called, then the encrypted value is never decrypted


### PR DESCRIPTION
(pattern extracted from: http://thepugautomatic.com/2013/07/dsom/ )

You can then, for example, migrate to encrypted records one by one, when they change:

```
class EncryptBankAccount < ActiveRecord::Migration
  def change
    rename_column :users, :bank_account_number, :clear_bank_account_number
    add_column :users, :encrypted_bank_account_number, :text
  end
end

class User < ActiveRecord::Base
  attr_encrypted :bank_account_number
  def bank_account_number
     super || clear_bank_account_number
  end
end
```

And later, drop the `clear_bank_account_numner` and delete the `bank_account_number` method.
