### PR TITLE
Add runtime dependency on "highline" gem

### DIFF
--- a/symmetric-encryption.gemspec
+++ b/symmetric-encryption.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |s|
   s.files       = Dir["{lib,examples}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
   s.test_files  = Dir["test/**/*"]
   s.license     = "Apache License V2.0"
+
+  s.add_runtime_dependency "highline"
 end


### PR DESCRIPTION
Add a runtime dependency on "highline" to symmetric-encryption.gemspec to resolve issue #24
