### PR TITLE
Fix decrypt_as logic for mongoid fields

### DIFF
--- a/lib/symmetric_encryption/mongoid.rb
+++ b/lib/symmetric_encryption/mongoid.rb
@@ -95,7 +95,9 @@ Mongoid::Fields.option :encrypted do |model, field, options|
     decrypted_field_name = options.delete(:decrypt_as)
     if decrypted_field_name.nil? && encrypted_field_name.to_s.start_with?('encrypted_')
       decrypted_field_name = encrypted_field_name.to_s['encrypted_'.length..-1]
-    else
+    end
+  
+    if decrypted_field_name.nil?
       raise "SymmetricEncryption for Mongoid. Encryption enabled for field #{encrypted_field_name}. It must either start with 'encrypted_' or the option :decrypt_as must be supplied"
     end
 


### PR DESCRIPTION
There was a minor issue when using the `decrypt_as` option when specifying a mongoid field with an `alias`.
The original check was:

```
if decrypted_field_name.nil? && encrypted_field_name.to_s.start_with?('encrypted_')
```

However, this will always return false for the following field definition:

```
field :ad1, type: String, encrypted: {decrypt_as: :address1, random_iv: true}
```

Since the field name is _ad1_, the condition will return false despite the fact that the `decrypt_as` option was given, and an error will be raised. I don't think the intention was to check that the field name starts with _encrypted__ if `decrypt_as` is given. Am I correct?

This quick change should fix the issue.
