### PR TITLE
Fix coercion

### DIFF
--- a/lib/symmetric_encryption/extensions/active_record/base.rb
+++ b/lib/symmetric_encryption/extensions/active_record/base.rb
@@ -81,8 +81,9 @@ module ActiveRecord #:nodoc:
             # Set the un-encrypted attribute
             # Also updates the encrypted field with the encrypted value
             def #{attribute}=(value)
-              self.encrypted_#{attribute} = @stored_encrypted_#{attribute} = ::SymmetricEncryption.encrypt(value,#{random_iv},#{compress},:#{type})
-              @#{attribute} = value.freeze
+              v = SymmetricEncryption::coerce(value, :#{type})
+              self.encrypted_#{attribute} = @stored_encrypted_#{attribute} = ::SymmetricEncryption.encrypt(v,#{random_iv},#{compress},:#{type})
+              @#{attribute} = v.freeze
             end
           UNENCRYPTED
 

--- a/lib/symmetric_encryption/mongoid.rb
+++ b/lib/symmetric_encryption/mongoid.rb
@@ -96,7 +96,7 @@ Mongoid::Fields.option :encrypted do |model, field, options|
     if decrypted_field_name.nil? && encrypted_field_name.to_s.start_with?('encrypted_')
       decrypted_field_name = encrypted_field_name.to_s['encrypted_'.length..-1]
     end
-  
+
     if decrypted_field_name.nil?
       raise "SymmetricEncryption for Mongoid. Encryption enabled for field #{encrypted_field_name}. It must either start with 'encrypted_' or the option :decrypt_as must be supplied"
     end
@@ -121,8 +121,9 @@ Mongoid::Fields.option :encrypted do |model, field, options|
       # Also updates the encrypted field with the encrypted value
       # Freeze the decrypted field value so that it is not modified directly
       def #{decrypted_field_name}=(value)
-        self.#{encrypted_field_name} = @stored_#{encrypted_field_name} = ::SymmetricEncryption.encrypt(value,#{random_iv},#{compress},:#{type})
-        @#{decrypted_field_name} = value.freeze
+        v = SymmetricEncryption::coerce(value, :#{type})
+        self.#{encrypted_field_name} = @stored_#{encrypted_field_name} = ::SymmetricEncryption.encrypt(v,#{random_iv},#{compress},:#{type})
+        @#{decrypted_field_name} = v.freeze
       end
 
       # Returns the decrypted value for the encrypted field

--- a/lib/symmetric_encryption/symmetric_encryption.rb
+++ b/lib/symmetric_encryption/symmetric_encryption.rb
@@ -455,6 +455,23 @@ module SymmetricEncryption
     Cipher.new(config)
   end
 
+  # Coerce given value into given type
+  # Does not coerce json or yaml values
+  def self.coerce(value, type, from_type=nil)
+    return if value.nil?
+
+    from_type ||= value.class
+    case type
+    when :json
+      value
+    when :yaml
+      value
+    else
+      coercer = Coercible::Coercer.new
+      coercer[from_type].send("to_#{type}".to_sym, value)
+    end
+  end
+
   # Uses coercible gem to coerce values from strings into the target type
   # Note: if the type is :string, then the value is returned as is, and the
   #   coercible gem is not used at all.
@@ -468,9 +485,7 @@ module SymmetricEncryption
     when :yaml
       YAML.load(value)
     else
-      coercer = Coercible::Coercer.new
-      coercion_method = "to_#{type}".to_sym
-      coercer[String].send(coercion_method, value)
+      self.coerce(value, type, String)
     end
   end
 
@@ -488,8 +503,7 @@ module SymmetricEncryption
     when :yaml
       value.to_yaml
     else
-      coercer = Coercible::Coercer.new
-      coercer[coercion_type(type, value)].to_string(value)
+      self.coerce(value, :string, coercion_type(type, value))
     end
   end
 

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -231,6 +231,8 @@ class AttrEncryptedTest < Test::Unit::TestCase
       assert_equal true, @user.valid?
     end
 
+
+
     context "with saved user" do
       setup do
         @user.save!
@@ -238,6 +240,12 @@ class AttrEncryptedTest < Test::Unit::TestCase
 
       teardown do
         @user.destroy
+      end
+
+      should "return correct data type before save" do
+        u = User.new(:integer_value => "5")
+        assert_equal 5, u.integer_value
+        assert u.integer_value.kind_of?(Integer)
       end
 
       should "handle gsub! for non-encrypted_field" do
@@ -290,6 +298,12 @@ class AttrEncryptedTest < Test::Unit::TestCase
             assert @user.clone.integer_value.kind_of?(Integer)
           end
 
+          should "coerce data type before save" do
+            u = User.new(:integer_value => "5")
+            assert_equal 5, u.integer_value
+            assert u.integer_value.kind_of?(Integer)
+          end
+
           should "permit replacing value with nil" do
             @user_clone.integer_value = nil
             @user_clone.save!
@@ -313,6 +327,12 @@ class AttrEncryptedTest < Test::Unit::TestCase
           should "return correct data type" do
             assert_equal @float_value, @user_clone.float_value
             assert @user.clone.float_value.kind_of?(Float)
+          end
+
+          should "coerce data type before save" do
+            u = User.new(:float_value => "5.6")
+            assert_equal 5.6, u.float_value
+            assert u.float_value.kind_of?(Float)
           end
 
           should "permit replacing value with nil" do
@@ -340,6 +360,12 @@ class AttrEncryptedTest < Test::Unit::TestCase
             assert @user.clone.decimal_value.kind_of?(BigDecimal)
           end
 
+          should "coerce data type before save" do
+            u = User.new(:decimal_value => "99.95")
+            assert_equal BigDecimal.new("99.95"), u.decimal_value
+            assert u.decimal_value.kind_of?(BigDecimal)
+          end
+
           should "permit replacing value with nil" do
             @user_clone.decimal_value = nil
             @user_clone.save!
@@ -363,6 +389,13 @@ class AttrEncryptedTest < Test::Unit::TestCase
           should "return correct data type" do
             assert_equal @datetime_value, @user_clone.datetime_value
             assert @user.clone.datetime_value.kind_of?(DateTime)
+          end
+
+          should "coerce data type before save" do
+            now = Time.now
+            u = User.new(:datetime_value => now)
+            assert_equal now, u.datetime_value
+            assert u.datetime_value.kind_of?(DateTime)
           end
 
           should "permit replacing value with nil" do
@@ -390,6 +423,13 @@ class AttrEncryptedTest < Test::Unit::TestCase
             assert @user.clone.time_value.kind_of?(Time)
           end
 
+          should "coerce data type before save" do
+            now = Time.now
+            u = User.new(:time_value => now)
+            assert_equal now, u.time_value
+            assert u.time_value.kind_of?(Time)
+          end
+
           should "permit replacing value with nil" do
             @user_clone.time_value = nil
             @user_clone.save!
@@ -413,6 +453,13 @@ class AttrEncryptedTest < Test::Unit::TestCase
           should "return correct data type" do
             assert_equal @date_value, @user_clone.date_value
             assert @user.clone.date_value.kind_of?(Date)
+          end
+
+          should "coerce data type before save" do
+            now = Time.now
+            u = User.new(:date_value => now)
+            assert_equal now.to_date, u.date_value
+            assert u.date_value.kind_of?(Date)
           end
 
           should "permit replacing value with nil" do
@@ -440,6 +487,12 @@ class AttrEncryptedTest < Test::Unit::TestCase
             assert @user.clone.true_value.kind_of?(TrueClass)
           end
 
+          should "coerce data type before save" do
+            u = User.new(:true_value => "1")
+            assert_equal true, u.true_value
+            assert u.true_value.kind_of?(TrueClass)
+          end
+
           should "permit replacing value with nil" do
             @user_clone.true_value = nil
             @user_clone.save!
@@ -463,6 +516,12 @@ class AttrEncryptedTest < Test::Unit::TestCase
           should "return correct data type" do
             assert_equal false, @user_clone.false_value
             assert @user.clone.false_value.kind_of?(FalseClass)
+          end
+
+          should "coerce data type before save" do
+            u = User.new(:false_value => "0")
+            assert_equal false, u.false_value
+            assert u.false_value.kind_of?(FalseClass)
           end
 
           should "permit replacing value with nil" do
@@ -499,6 +558,12 @@ class AttrEncryptedTest < Test::Unit::TestCase
             assert @user.clone.data_json.kind_of?(Hash)
           end
 
+          should "not coerce data type (leaves as hash) before save" do
+            u = User.new(:data_json => @h)
+            assert_equal @h, u.data_json
+            assert u.data_json.kind_of?(Hash)
+          end
+
           should "permit replacing value with nil" do
             @user_clone.data_json = nil
             @user_clone.save!
@@ -523,6 +588,12 @@ class AttrEncryptedTest < Test::Unit::TestCase
           should "return correct data type" do
             assert_equal @h, @user_clone.data_yaml
             assert @user.clone.data_yaml.kind_of?(Hash)
+          end
+
+          should "not coerce data type (leaves as hash) before save" do
+            u = User.new(:data_yaml => @h)
+            assert_equal @h, u.data_yaml
+            assert u.data_yaml.kind_of?(Hash)
           end
 
           should "permit replacing value with nil" do

--- a/test/field_encrypted_test.rb
+++ b/test/field_encrypted_test.rb
@@ -201,13 +201,20 @@ class FieldEncryptedTest < Test::Unit::TestCase
         @user_clone = MongoidUser.find(@user.id)
       end
 
+      context "aliased fields" do
+        should "return correct data type" do
+          @user_clone.aliased_integer_value = "5"
+          assert_equal 5, @user_clone.aliased_integer_value
+        end
+      end
+
       context "integer values" do
         should "return correct data type" do
           assert_equal @integer_value, @user_clone.integer_value
           assert @user.clone.integer_value.kind_of?(Integer)
         end
 
-        should "return correct data type before save" do
+        should "coerce data type before save" do
           u = MongoidUser.new(:integer_value => "5")
           assert_equal 5, u.integer_value
           assert u.integer_value.kind_of?(Integer)
@@ -238,6 +245,12 @@ class FieldEncryptedTest < Test::Unit::TestCase
           assert @user.clone.float_value.kind_of?(Float)
         end
 
+        should "coerce data type before save" do
+          u = MongoidUser.new(:float_value => "5.6")
+          assert_equal 5.6, u.float_value
+          assert u.float_value.kind_of?(Float)
+        end
+
         should "permit replacing value with nil" do
           @user_clone.float_value = nil
           @user_clone.save!
@@ -261,6 +274,12 @@ class FieldEncryptedTest < Test::Unit::TestCase
         should "return correct data type" do
           assert_equal @decimal_value, @user_clone.decimal_value
           assert @user.clone.decimal_value.kind_of?(BigDecimal)
+        end
+
+        should "coerce data type before save" do
+          u = MongoidUser.new(:decimal_value => "99.95")
+          assert_equal BigDecimal.new("99.95"), u.decimal_value
+          assert u.decimal_value.kind_of?(BigDecimal)
         end
 
         should "permit replacing value with nil" do
@@ -288,6 +307,13 @@ class FieldEncryptedTest < Test::Unit::TestCase
           assert @user.clone.datetime_value.kind_of?(DateTime)
         end
 
+        should "coerce data type before save" do
+          now = Time.now
+          u = MongoidUser.new(:datetime_value => now)
+          assert_equal now, u.datetime_value
+          assert u.datetime_value.kind_of?(DateTime)
+        end
+
         should "permit replacing value with nil" do
           @user_clone.datetime_value = nil
           @user_clone.save!
@@ -311,6 +337,13 @@ class FieldEncryptedTest < Test::Unit::TestCase
         should "return correct data type" do
           assert_equal @time_value, @user_clone.time_value
           assert @user.clone.time_value.kind_of?(Time)
+        end
+
+        should "coerce data type before save" do
+          now = Time.now
+          u = MongoidUser.new(:time_value => now)
+          assert_equal now, u.time_value
+          assert u.time_value.kind_of?(Time)
         end
 
         should "permit replacing value with nil" do
@@ -338,6 +371,13 @@ class FieldEncryptedTest < Test::Unit::TestCase
           assert @user.clone.date_value.kind_of?(Date)
         end
 
+        should "coerce data type before save" do
+          now = Time.now
+          u = MongoidUser.new(:date_value => now)
+          assert_equal now.to_date, u.date_value
+          assert u.date_value.kind_of?(Date)
+        end
+
         should "permit replacing value with nil" do
           @user_clone.date_value = nil
           @user_clone.save!
@@ -363,6 +403,12 @@ class FieldEncryptedTest < Test::Unit::TestCase
           assert @user.clone.true_value.kind_of?(TrueClass)
         end
 
+        should "coerce data type before save" do
+          u = MongoidUser.new(:true_value => "1")
+          assert_equal true, u.true_value
+          assert u.true_value.kind_of?(TrueClass)
+        end
+
         should "permit replacing value with nil" do
           @user_clone.true_value = nil
           @user_clone.save!
@@ -386,6 +432,12 @@ class FieldEncryptedTest < Test::Unit::TestCase
         should "return correct data type" do
           assert_equal false, @user_clone.false_value
           assert @user.clone.false_value.kind_of?(FalseClass)
+        end
+
+        should "coerce data type before save" do
+          u = MongoidUser.new(:false_value => "0")
+          assert_equal false, u.false_value
+          assert u.false_value.kind_of?(FalseClass)
         end
 
         should "permit replacing value with nil" do
@@ -422,6 +474,12 @@ class FieldEncryptedTest < Test::Unit::TestCase
           assert @user.clone.data_json.kind_of?(Hash)
         end
 
+        should "not coerce data type (leaves as hash) before save" do
+          u = MongoidUser.new(:data_json => @h)
+          assert_equal @h, u.data_json
+          assert u.data_json.kind_of?(Hash)
+        end
+
         should "permit replacing value with nil" do
           @user_clone.data_json = nil
           @user_clone.save!
@@ -448,6 +506,12 @@ class FieldEncryptedTest < Test::Unit::TestCase
           assert @user.clone.data_yaml.kind_of?(Hash)
         end
 
+        should "not coerce data type (leaves as hash) before save" do
+          u = MongoidUser.new(:data_yaml => @h)
+          assert_equal @h, u.data_yaml
+          assert u.data_yaml.kind_of?(Hash)
+        end
+
         should "permit replacing value with nil" do
           @user_clone.data_yaml = nil
           @user_clone.save!
@@ -465,13 +529,6 @@ class FieldEncryptedTest < Test::Unit::TestCase
 
           @user.reload
           assert_equal new_value, @user.data_yaml
-        end
-      end
-
-      context "aliased fields" do
-        should "return correct data type" do
-          @user_clone.aliased_integer_value = "5"
-          assert_equal 5, @user_clone.aliased_integer_value
         end
       end
 


### PR DESCRIPTION
Fixes #28

These changes attempt to coerce values according to their field types on the setters. This is necessary because we might create a model straight from rails parameters and parameter values can sometimes be strings. Usually, the ORM will take care of this subtlety.

For example, a boolean from a submitted form might take the value of `"1"` instead of `true`. If the values are not coerced, then some unintended consequences will follow such as model validations failing. 
