### PR TITLE
Improves the messaging of the heroku generator

### DIFF
--- a/lib/rails/generators/symmetric_encryption/heroku_config/templates/symmetric-encryption.yml
+++ b/lib/rails/generators/symmetric_encryption/heroku_config/templates/symmetric-encryption.yml
@@ -22,8 +22,8 @@ iv            = ::Base64.strict_encode64(key_pair[:iv])
 encrypted_key = ::Base64.strict_encode64(rsa_key.public_encrypt(key_pair[:key]))
 
 puts "\n\n********************************************************************************"
-puts "Add the following environment setting to your heroku 'release' environment:\n\n"
-puts "  RELEASE_KEY1=\"#{encrypted_key}\"\n\n"
+puts "Add the following environment variables to heroku:\n\n"
+puts "  heroku config:set RELEASE_KEY1:#{encrypted_key}\n\n"
 -%>
 release:
   # Since the key to encrypt and decrypt with must NOT be stored along with the
@@ -51,8 +51,7 @@ key_pair      = SymmetricEncryption::Cipher.random_key_pair(cipher_name)
 iv            = ::Base64.strict_encode64(key_pair[:iv])
 encrypted_key = ::Base64.strict_encode64(rsa_key.public_encrypt(key_pair[:key]))
 
-puts "Add the following environment setting to your heroku 'production' environment:\n\n"
-puts "  PRODUCTION_KEY1=\"#{encrypted_key}\"\n\n"
+puts "  heroku config:set PRODUCTION_KEY1:#{encrypted_key}\n\n"
 puts "********************************************************************************\n\n\n"
 -%>
 production:


### PR DESCRIPTION
I set my heroku config like this `heroku config:set RELEASE_KEY1=blah` (notice the equal sign) and I was getting weird errors on heroku deploy like below. I also tried with and without quotes.

```
padding check failed
/.rvm/gems/ruby-2.0.0-p247/bundler/gems/symmetric-encryption-a0d55cf6e32d/lib/symmetric_encryption/symmetric_encryption.rb:441:in `private_decrypt'
/.rvm/gems/ruby-2.0.0-p247/bundler/gems/symmetric-encryption-a0d55cf6e32d/lib/symmetric_encryption/symmetric_encryption.rb:441:in `cipher_from_config'
/.rvm/gems/ruby-2.0.0-p247/bundler/gems/symmetric-encryption-a0d55cf6e32d/lib/symmetric_encryption/symmetric_encryption.rb:351:in `block in read_config'
/.rvm/gems/ruby-2.0.0-p247/bundler/gems/symmetric-encryption-a0d55cf6e32d/lib/symmetric_encryption/symmetric_encryption.rb:351:in `collect'
/.rvm/gems/ruby-2.0.0-p247/bundler/gems/symmetric-encryption-a0d55cf6e32d/lib/symmetric_encryption/symmetric_encryption.rb:351:in `read_config'
/.rvm/gems/ruby-2.0.0-p247/bundler/gems/symmetric-encryption-a0d55cf6e32d/lib/symmetric_encryption/symmetric_encryption.rb:258:in `load!'
/.rvm/gems/ruby-2.0.0-p247/bundler/gems/symmetric-encryption-a0d55cf6e32d/lib/symmetric_encryption/railtie.rb:40:in `block in <class:Railtie>'
/.rvm/gems/ruby-2.0.0-p247/gems/activesupport-4.0.2/lib/active_support/lazy_load_hooks.rb:36:in `call'
/.rvm/gems/ruby-2.0.0-p247/gems/activesupport-4.0.2/lib/active_support/lazy_load_hooks.rb:36:in `execute_hook'
/.rvm/gems/ruby-2.0.0-p247/gems/activesupport-4.0.2/lib/active_support/lazy_load_hooks.rb:45:in `block in run_load_hooks'
/.rvm/gems/ruby-2.0.0-p247/gems/activesupport-4.0.2/lib/active_support/lazy_load_hooks.rb:44:in `each'
/.rvm/gems/ruby-2.0.0-p247/gems/activesupport-4.0.2/lib/active_support/lazy_load_hooks.rb:44:in `run_load_hooks'
/.rvm/gems/ruby-2.0.0-p247/gems/railties-4.0.2/lib/rails/application.rb:67:in `inherited'
```

However, if I set the heroku config like this `heroku config:set RELEASE_KEY1:blah` (notice the colon instead of equal sign), then everything worked fine. This PR changes the generator to stop people from making this mistake.
