### PR TITLE
Fixes output from generate_symmetric_key_files

### DIFF
--- a/lib/symmetric_encryption/symmetric_encryption.rb
+++ b/lib/symmetric_encryption/symmetric_encryption.rb
@@ -311,7 +311,7 @@ module SymmetricEncryption
     elsif !cipher_cfg[:iv]
       iv = rsa_key.public_encrypt(key_pair[:iv])
       puts "Generated new Symmetric Key for encryption. Set the IV environment variable in #{environment} to:"
-      puts ::Base64.encode64(key)
+      puts ::Base64.encode64(iv)
     end
   end
 


### PR DESCRIPTION
When using the Heroku config (ENV vars) for encryption,
generate_symmetric_key_files would output the key as the iv when no iv
was included in the symmetric-encryption.yml file. This change simply
outputs the correct value.
