### PR TITLE
Handle a missing encrypted_key or iv for keygen

### DIFF
--- a/lib/symmetric_encryption/symmetric_encryption.rb
+++ b/lib/symmetric_encryption/symmetric_encryption.rb
@@ -438,6 +438,11 @@ module SymmetricEncryption
       raise "Missing mandatory config parameter :private_rsa_key when :encrypted_key is supplied" unless rsa
       # Decode value first using encoding specified
       encrypted_key = ::Base64.decode64(encrypted_key)
+      if !encrypted_key || encrypted_key.empty?
+        puts "\nSymmetric Encryption encrypted_key not found."
+        puts "To generate the keys for the first time run: rails generate symmetric_encryption:new_keys\n\n"
+        return
+      end
       config[:key] = rsa.private_decrypt(encrypted_key)
     end
 
@@ -445,6 +450,11 @@ module SymmetricEncryption
       raise "Missing mandatory config parameter :private_rsa_key when :encrypted_iv is supplied" unless rsa
       # Decode value first using encoding specified
       encrypted_iv = ::Base64.decode64(encrypted_iv)
+      if !encrypted_key || encrypted_key.empty?
+        puts "\nSymmetric Encryption encrypted_iv not found."
+        puts "To generate the keys for the first time run: rails generate symmetric_encryption:new_keys\n\n"
+        return
+      end
       config[:iv] = rsa.private_decrypt(encrypted_iv)
     end
 


### PR DESCRIPTION
Previously if you tried to use encrypted_key/encrypted_iv and had not
loaded them into the ENV (or wherever they will come from) yet, you
would not be able to generate new keys in that environment using `rails generate
symmetric_encryption:new_keys` because the Cipher would error out.

This change handles missing encrypted_key or encrypted_iv the same way
we handle missing files when using key_filename or iv_filename in a
given environment.

This way you can actually run the generator in the target environment
without it blowing up.
