### PR TITLE
Using unsupported options causes a load error due to missing variable

### DIFF
--- a/lib/symmetric_encryption/extensions/active_record/base.rb
+++ b/lib/symmetric_encryption/extensions/active_record/base.rb
@@ -44,7 +44,7 @@ module ActiveRecord #:nodoc:
         options   = params.last.is_a?(Hash) ? params.pop.dup : {}
 
         params.each do |attribute|
-          SymmetricEncryption::Generator.generate_decrypted_accessors(self, attribute, "encrypted_#{attribute}", options, params)
+          SymmetricEncryption::Generator.generate_decrypted_accessors(self, attribute, "encrypted_#{attribute}", options)
           encrypted_attributes[attribute.to_sym] = "encrypted_#{attribute}".to_sym
         end
       end

--- a/lib/symmetric_encryption/generator.rb
+++ b/lib/symmetric_encryption/generator.rb
@@ -2,7 +2,7 @@ module SymmetricEncryption
   module Generator
     # Common internal method for generating accessors for decrypted accessors
     # Primarily used by extensions
-    def self.generate_decrypted_accessors(model, decrypted_name, encrypted_name, options, params)
+    def self.generate_decrypted_accessors(model, decrypted_name, encrypted_name, options)
 
       random_iv      = options.delete(:random_iv) || false
       compress       = options.delete(:compress) || false
@@ -15,7 +15,7 @@ module SymmetricEncryption
         type = :yaml
       end
 
-      options.each {|option| warn "Ignoring unknown option #{option.inspect} supplied when encrypting #{decrypted_name} with #{params.inspect}"}
+      options.each {|option| warn "Ignoring unknown option #{option.inspect} supplied when encrypting #{decrypted_name}"}
 
       raise "Invalid type: #{type.inspect}. Valid types: #{SymmetricEncryption::COERCION_TYPES.inspect}" unless SymmetricEncryption::COERCION_TYPES.include?(type)
 


### PR DESCRIPTION
Adding an option to attr_encrypted that is not supported by Symmetric Encryption causes an exception due to the params variable not being passed to the warn.

I've set the variable to be passed and added a test to confirm. Having the unsupported option present is all that is really needed to test as it prevents load, but I've added an explicit test so it will be clear why it is there in future changes.

I discovered this when using the gem [tinfoil/devise-two-factor](github.com/tinfoil/devise-two-factor). This gem uses attr_encrypted's `:key` and `:mode` options [here](https://github.com/tinfoil/devise-two-factor/blob/master/lib/devise_two_factor/models/two_factor_authenticatable.rb#L12).
