### PR TITLE
Make accessor overrides call #super if available

### DIFF
--- a/lib/symmetric_encryption/generator.rb
+++ b/lib/symmetric_encryption/generator.rb
@@ -26,7 +26,8 @@ module SymmetricEncryption
         def #{decrypted_name}=(value)
           v = SymmetricEncryption::Coerce.coerce(value, :#{type})
           self.#{encrypted_name} = @stored_#{encrypted_name} = ::SymmetricEncryption.encrypt(v,#{random_iv},#{compress},:#{type})
-          @#{decrypted_name} = v.freeze
+
+          defined?(super) ? super : (@#{decrypted_name} = v.freeze)
         end
 
         # Returns the decrypted value for the encrypted field
@@ -34,10 +35,11 @@ module SymmetricEncryption
         # If this method is not called, then the encrypted value is never decrypted
         def #{decrypted_name}
           if @stored_#{encrypted_name} != self.#{encrypted_name}
-            @#{decrypted_name} = ::SymmetricEncryption.decrypt(self.#{encrypted_name},version=nil,:#{type}).freeze
+            self.#{decrypted_name} = ::SymmetricEncryption.decrypt(self.#{encrypted_name},version=nil,:#{type}).freeze
             @stored_#{encrypted_name} = self.#{encrypted_name}
           end
-          @#{decrypted_name}
+
+          defined?(super) ? super.freeze : @#{decrypted_name}
         end
 
         # Map changes to encrypted value to unencrypted equivalent

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -1,5 +1,4 @@
 require_relative 'test_helper'
-require 'pry'
 
 ActiveRecord::Base.logger         = SemanticLogger[ActiveRecord]
 ActiveRecord::Base.configurations = YAML::load(ERB.new(IO.read('test/config/database.yml')).result)


### PR DESCRIPTION
Hi Reid,

Thanks a lot for your work on this helpful gem!

I came across an issue, though. I'm using this with Rails, and I was finding some strange bugs.

For example, if I had a `User` model inheriting from ActiveRecord, calling `some_user.inspect` to see all of the attributes would show `nil` for the values of the attributes that were using `attr_encrypted`. The non-encrypted fields would be fine.

Also, calling `some_user.attributes` to get a hash of the attributes would have all `attr_encrypted` attributes set to `nil`; but attempting to get the value of one specific `attr_encrypted` attribute (for example, `some_user.first_name`) would return the correct value.

Digging into it, it appears to be because the accessor override methods set the instance variables directly, rather than going through `#super`, if it's available.

This pretty much affects all `attr_encrypted` attributes on any Ruby class that has an overridden reader/writer method. In essence, those methods weren't getting called.

I've attached some code that should fix the issue though, along with some tests.

Please let me know what you think, or if you'd like some log output or anything.