### PR TITLE
fix error on new key generation

### DIFF
--- a/lib/symmetric_encryption/cipher.rb
+++ b/lib/symmetric_encryption/cipher.rb
@@ -144,7 +144,6 @@ module SymmetricEncryption
         cipher_conf[:iv] = iv.to_s
       end
 
-      raise(ArgumentError, "SymmetricEncryption::Cipher Invalid options #{params.inspect}") if params.size > 0
       cipher_conf
     end
 


### PR DESCRIPTION
I'm not sure if it's the right approach, 
but this fixes the problem when trying to generate a new key using 
`rails generate symmetric_encryption:new_keys production`
