### PR TITLE
Fix key generation for development and test enviorement

### DIFF
--- a/lib/symmetric_encryption/cipher.rb
+++ b/lib/symmetric_encryption/cipher.rb
@@ -130,7 +130,8 @@ module SymmetricEncryption
         encrypted_key               = key_encryption_key.encrypt(key)
         cipher_conf[:encrypted_key] = SymmetricEncryption::Encoder[encoding].encode(encrypted_key)
       else
-        cipher_conf[:key] = key.to_s
+        params.delete(:key)
+        cipher_conf[:key] = SymmetricEncryption::Encoder[encoding].encode(key.to_s)
       end
 
       if file_name = params.delete(:iv_filename)
@@ -141,7 +142,8 @@ module SymmetricEncryption
         encrypted_iv               = key_encryption_key.encrypt(iv)
         cipher_conf[:encrypted_iv] = SymmetricEncryption::Encoder[encoding].encode(encrypted_iv)
       else
-        cipher_conf[:iv] = iv.to_s
+        params.delete(:iv)
+        cipher_conf[:iv] = SymmetricEncryption::Encoder[encoding].encode(iv.to_s)
       end
 
       raise(ArgumentError, "SymmetricEncryption::Cipher Invalid options #{params.inspect}") if params.size > 0

--- a/lib/symmetric_encryption/symmetric_encryption.rb
+++ b/lib/symmetric_encryption/symmetric_encryption.rb
@@ -290,6 +290,14 @@ module SymmetricEncryption
       puts "heroku config:add #{environment.upcase}_IV1=#{encoded_encrypted_iv}"
     end
 
+    if key = cipher_cfg[:key]
+      puts "Please add the key: #{key} to your config file"
+    end
+
+    if iv = cipher_cfg[:iv]
+      puts "Please add the iv: #{iv} to your config file"
+    end
+
     if file_name = cipher_cfg[:key_filename]
       puts("Please copy #{file_name} to the other servers in #{environment}.")
     end

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -184,9 +184,19 @@ class CipherTest < Minitest::Test
       end
     end
 
-    describe 'with keys' do
+    describe 'without keys' do
       it 'creates new keys' do
         h = SymmetricEncryption::Cipher.generate_random_keys
+        assert_equal 'aes-256-cbc', h[:cipher_name]
+        assert_equal :base64strict, h[:encoding]
+        assert h.has_key?(:key), h
+        assert h.has_key?(:iv), h
+      end
+    end
+
+    describe 'with keys' do
+      it 'creates new keys' do
+        h = SymmetricEncryption::Cipher.generate_random_keys(key: '', iv: '')
         assert_equal 'aes-256-cbc', h[:cipher_name]
         assert_equal :base64strict, h[:encoding]
         assert h.has_key?(:key), h


### PR DESCRIPTION
The same error that happened here https://github.com/rocketjob/symmetric-encryption/issues/72, happens for `development` and `test` enviorement.

Because when the config file got read, the keys: `key and iv`, which exists under the `development` and `test` keys, are loaded and passed to the [Chiper.generate_random_keys](https://github.com/rocketjob/symmetric-encryption/blob/master/lib/symmetric_encryption/cipher.rb#L107), but they weren't removed, which causes the exception to be raised.

What I did, is do to delete the keys from the params, if the [else](https://github.com/rocketjob/symmetric-encryption/compare/master...westfield:master#diff-733b79581b0e4731ad6bfe4fc60f9eadR133) happens.
This way the generate keys will continue working even if you don't pass any arg.