### PR TITLE
Allow explicitly setting environment requested from config file

### DIFF
--- a/lib/symmetric_encryption/cli.rb
+++ b/lib/symmetric_encryption/cli.rb
@@ -16,7 +16,7 @@ module SymmetricEncryption
 
     def initialize(argv)
       @version          = current_version
-      @environment      = ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development'
+      @environment      = ENV['SYMMETRIC_ENCRYPTION_ENV'] || ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development'
       @config_file_path = File.expand_path(ENV['SYMMETRIC_ENCRYPTION_CONFIG'] || 'config/symmetric-encryption.yml')
       @app_name         = 'symmetric-encryption'
       @key_path         = '/etc/symmetric-encryption'
@@ -103,7 +103,7 @@ module SymmetricEncryption
           @compress = true
         end
 
-        opts.on '-E', '--env ENVIRONMENT', "Environment to use in the config file. Default: RACK_ENV || RAILS_ENV || 'development'" do |environment|
+        opts.on '-E', '--env ENVIRONMENT', "Environment to use in the config file. Default: SYMMETRIC_ENCRYPTION_ENV || RACK_ENV || RAILS_ENV || 'development'" do |environment|
           @environment = environment
         end
 

--- a/lib/symmetric_encryption/railtie.rb
+++ b/lib/symmetric_encryption/railtie.rb
@@ -33,7 +33,7 @@ module SymmetricEncryption #:nodoc:
         config_file = Rails.root.join('config', 'symmetric-encryption.yml')
         if config_file.file?
           begin
-            ::SymmetricEncryption::Config.load!(file_name: config_file, env: Rails.env)
+            ::SymmetricEncryption::Config.load!(file_name: config_file, env: ENV['SYMMETRIC_ENCRYPTION_ENV'] || Rails.env)
           rescue ArgumentError => exc
             puts "\nSymmetric Encryption not able to read keys."
             puts "#{exc.class.name} #{exc.message}"


### PR DESCRIPTION
Allows using "production" RACK_ENV/RAILS_ENV, while specifying separate env from the config file

### Issue # (if available)

Discussed in #87 — basically, for Rails apps, you normally want to set the RAILS_ENV to `production` (see Heroku's comment on this here: https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment). When using the same `config/symmetric-encryption.yml` on multiple deployments (eg on Heroku stage/acceptance/production), you need a way to specify which node on the config file you'd like to use. 

This could also be handled by adding separate config files for each deploy environment and using `ENV['SYMMETRIC_ENCRYPTION_CONFIG']`, but this method seems more elegant.

### Description of changes

Added the ability to specify, with `ENV['SYMMETRIC_ENCRYPTION_CONFIG']`, which node is used on the yaml config, beyond just using RACK_ENV or RAILS_ENV.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
