### PR TITLE
Support output buffer in Reader#read and drastically reduce Reader & Writer memory usage

### DIFF
--- a/lib/symmetric_encryption/reader.rb
+++ b/lib/symmetric_encryption/reader.rb
@@ -98,14 +98,7 @@ module SymmetricEncryption
     # Notes:
     # * The file contents are streamed so that the entire file is _not_ loaded into memory.
     def self.decrypt(source:, target:, block_size: 65_535, **args)
-      target_ios    = target.is_a?(String) ? ::File.open(target, 'wb') : target
-      bytes_written = 0
-      self.open(source, **args) do |input_ios|
-        bytes_written += target_ios.write(input_ios.read(block_size)) until input_ios.eof?
-      end
-      bytes_written
-    ensure
-      target_ios.close if target_ios&.respond_to?(:closed?) && !target_ios.closed?
+      self.open(source, **args) { |input_file| IO.copy_stream(input_file, target) }
     end
 
     # Returns [true|false] whether the file or stream contains any data

--- a/lib/symmetric_encryption/reader.rb
+++ b/lib/symmetric_encryption/reader.rb
@@ -125,7 +125,7 @@ module SymmetricEncryption
       @version        = version
       @header_present = false
       @closed         = false
-      @read_buffer    = ''
+      @read_buffer    = ''.b
 
       raise(ArgumentError, 'Buffer size cannot be smaller than 128') unless @buffer_size >= 128
 
@@ -312,7 +312,7 @@ module SymmetricEncryption
       @pos = 0
 
       # Read first block and check for the header
-      buf = @ios.read(@buffer_size, @output_buffer ||= '')
+      buf = @ios.read(@buffer_size, @output_buffer ||= ''.b)
 
       # Use cipher specified in header, or global cipher if it has no header
       iv, key, cipher_name, cipher = nil
@@ -342,7 +342,7 @@ module SymmetricEncryption
 
     # Read a block of data and append the decrypted data in the read buffer
     def read_block(length = nil)
-      buf = @ios.read(length || @buffer_size, @output_buffer ||= '')
+      buf = @ios.read(length || @buffer_size, @output_buffer ||= ''.b)
       decrypt(buf)
     end
 
@@ -350,7 +350,7 @@ module SymmetricEncryption
     def decrypt(buf)
       return if buf.nil? || buf.empty?
 
-      @read_buffer << @stream_cipher.update(buf, @cipher_buffer ||= '')
+      @read_buffer << @stream_cipher.update(buf, @cipher_buffer ||= ''.b)
       @read_buffer << @stream_cipher.final if @ios.eof?
     end
 

--- a/lib/symmetric_encryption/reader.rb
+++ b/lib/symmetric_encryption/reader.rb
@@ -216,8 +216,11 @@ module SymmetricEncryption
       end
       @pos += data.length if data
       if output_buffer
-        output_buffer.replace data.to_s
-        data.clear if data # deallocate string
+        output_buffer.clear
+        if data
+          output_buffer << data
+          data.clear # deallocate string
+        end
         output_buffer unless output_buffer.empty? && length
       else
         data

--- a/lib/symmetric_encryption/reader.rb
+++ b/lib/symmetric_encryption/reader.rb
@@ -125,6 +125,7 @@ module SymmetricEncryption
       @version        = version
       @header_present = false
       @closed         = false
+      @output_buffer  = ''
 
       raise(ArgumentError, 'Buffer size cannot be smaller than 128') unless @buffer_size >= 128
 
@@ -326,7 +327,7 @@ module SymmetricEncryption
       @pos = 0
 
       # Read first block and check for the header
-      buf = @ios.read(@buffer_size)
+      buf = @ios.read(@buffer_size, @output_buffer)
 
       # Use cipher specified in header, or global cipher if it has no header
       iv, key, cipher_name, cipher = nil
@@ -362,7 +363,7 @@ module SymmetricEncryption
 
     # Read a block of data and append the decrypted data in the read buffer
     def read_block
-      buf = @ios.read(@buffer_size)
+      buf = @ios.read(@buffer_size, @output_buffer)
       @read_buffer << @stream_cipher.update(buf) if buf && !buf.empty?
       @read_buffer << @stream_cipher.final if @ios.eof?
     end

--- a/lib/symmetric_encryption/reader.rb
+++ b/lib/symmetric_encryption/reader.rb
@@ -364,7 +364,11 @@ module SymmetricEncryption
     # Read a block of data and append the decrypted data in the read buffer
     def read_block
       buf = @ios.read(@buffer_size, @output_buffer)
-      @read_buffer << @stream_cipher.update(buf) if buf && !buf.empty?
+      if buf && !buf.empty?
+        partial = @stream_cipher.update(buf)
+        @read_buffer << partial
+        partial.clear # deallocate string
+      end
       @read_buffer << @stream_cipher.final if @ios.eof?
     end
 

--- a/lib/symmetric_encryption/writer.rb
+++ b/lib/symmetric_encryption/writer.rb
@@ -160,6 +160,7 @@ module SymmetricEncryption
       @size   += bytes.size
       partial = @stream_cipher.update(bytes)
       @ios.write(partial) unless partial.empty?
+      partial.clear
       data.length
     end
 

--- a/lib/symmetric_encryption/writer.rb
+++ b/lib/symmetric_encryption/writer.rb
@@ -90,14 +90,7 @@ module SymmetricEncryption
     # Notes:
     # * The file contents are streamed so that the entire file is _not_ loaded into memory.
     def self.encrypt(source:, target:, block_size: 65_535, **args)
-      source_ios    = source.is_a?(String) ? ::File.open(source, 'rb') : source
-      bytes_written = 0
-      self.open(target, **args) do |output_file|
-        bytes_written += output_file.write(source_ios.read(block_size)) until source_ios.eof?
-      end
-      bytes_written
-    ensure
-      source_ios.close if source_ios&.respond_to?(:closed?) && !source_ios.closed?
+      self.open(target, **args) { |output_file| IO.copy_stream(source, output_file) }
     end
 
     # Encrypt data before writing to the supplied stream

--- a/lib/symmetric_encryption/writer.rb
+++ b/lib/symmetric_encryption/writer.rb
@@ -158,9 +158,8 @@ module SymmetricEncryption
 
       bytes   = data.to_s
       @size   += bytes.size
-      partial = @stream_cipher.update(bytes)
+      partial = @stream_cipher.update(bytes, @cipher_buffer ||= '')
       @ios.write(partial) unless partial.empty?
-      partial.clear
       data.length
     end
 

--- a/lib/symmetric_encryption/writer.rb
+++ b/lib/symmetric_encryption/writer.rb
@@ -158,7 +158,7 @@ module SymmetricEncryption
 
       bytes   = data.to_s
       @size   += bytes.size
-      partial = @stream_cipher.update(bytes, @cipher_buffer ||= '')
+      partial = @stream_cipher.update(bytes, @cipher_buffer ||= ''.b)
       @ios.write(partial) unless partial.empty?
       data.length
     end

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -184,6 +184,23 @@ class ReaderTest < Minitest::Test
             end
           end
 
+          it '#read(size, outbuf)' do
+            file          = SymmetricEncryption::Reader.open(@file_name)
+            eof           = file.eof?
+            output_buffer = "buffer"
+            data          = file.read(4096, output_buffer)
+            file.close
+
+            assert_equal @eof, eof
+            if @data_size.positive?
+              assert_equal @data_str, data
+              assert_equal data.object_id, output_buffer.object_id
+            else
+              assert_nil data
+              assert_empty output_buffer
+            end
+          end unless options[:compress]
+
           it '#each_line' do
             SymmetricEncryption::Reader.open(@file_name) do |file|
               i = 0


### PR DESCRIPTION
The `IO#read` method supports an optional second argument, the "output buffer". This allows reducing string allocations when reading the IO in chunks, because instead of chunks being allocated as new string, each chunk is read into the output buffer string (replacing the previous value).

Since `SymmetricEncryption::Reader` already mostly quacks like an IO object (and `Reader#read` already implements most of the semantics of the `IO#read` method), I thought it would be good to make it complete by also supporting the output buffer argument. That makes the `Reader` object usable in more scenarios; for example it can now be given as the first argument to `IO.copy_stream`, which was my use case and main motivation for making this pull request.

As a bonus, this allows greatly simplifying (and further optimizing) `Writer.encrypt` and `Reader.decrypt` by switching to `IO.copy_stream`. `IO.copy_stream` chooses its own buffer size (which turns out to be 16KB), so I wasn't able to use `:block_size`.