### PR TITLE
Halve memory usage of SymmetricEncryption::Writer

### DIFF
--- a/lib/symmetric_encryption/writer.rb
+++ b/lib/symmetric_encryption/writer.rb
@@ -167,6 +167,7 @@ module SymmetricEncryption
       @size   += bytes.size
       partial = @stream_cipher.update(bytes)
       @ios.write(partial) unless partial.empty?
+      partial.clear
       data.length
     end
 


### PR DESCRIPTION
String#clear in MRI immediately releases memory allocates from malloc(3), so it can make a lot of difference in keeping memory usage low. See this post by Eric Hodel from the ruby-talk mailing list:

https://rubytalk.org/t/psa-string-memory-use-reduction-techniques/74477

This commit clears the encrypted chunks of data after they written to the underlying IO object in `SymmetricEncryption::Writer#write`. This halves the memory usage of `Writer.encrypt`; previously encrypting a 50MB file would use 100MB of memory, and with this change it uses only 50MB.

If we also add changes from https://github.com/rocketjob/symmetric-encryption/pull/98, `SymmetricEncryption::Writer` doesn't use any additional memory (other than the size of a chunk), no matter how large the file is. I think that's a big win for encrypting large files 👌 