### PR TITLE
Add missing check ENV variable

### DIFF
--- a/lib/symmetric_encryption/railtie.rb
+++ b/lib/symmetric_encryption/railtie.rb
@@ -30,7 +30,11 @@ module SymmetricEncryption #:nodoc:
       # Check if already configured
       unless ::SymmetricEncryption.cipher?
         app_name    = Rails::Application.subclasses.first.parent.to_s.underscore
-        config_file = Rails.root.join('config', 'symmetric-encryption.yml')
+        if (env_var = ENV['SYMMETRIC_ENCRYPTION_CONFIG'])
+          config_file = Pathname.new File.expand_path(env_var)
+        else
+          config_file = Rails.root.join('config', 'symmetric-encryption.yml')
+        end
         if config_file.file?
           begin
             ::SymmetricEncryption::Config.load!(file_name: config_file, env: ENV['SYMMETRIC_ENCRYPTION_ENV'] || Rails.env)


### PR DESCRIPTION
### Issue # (if available)

Using SYMMETRIC_ENCRYPTION_CONFIG environment variable was not working. Perhaps forgot to test for this env variable in railtie.rb ?

### Description of changes

Also check for ENV variable in railtie.rb

Sorry, no test, maybe you can help me test it?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
