### PR TITLE
Fixed issues with named parameters as part of the generate CLI command.

### DIFF
--- a/lib/symmetric_encryption/cli.rb
+++ b/lib/symmetric_encryption/cli.rb
@@ -219,7 +219,7 @@ module SymmetricEncryption
       }
       args[:key_path]   = key_path if key_path
       args[:regions]    = regions if regions && !regions.empty?
-      cfg               = Keystore.generate_data_keys(keystore, **args)
+      cfg               = Keystore.generate_data_keys(keystore: keystore, **args)
       Config.write_file(config_file_path, cfg)
       puts "New configuration file created at: #{config_file_path}"
     end

--- a/lib/symmetric_encryption/keystore/aws.rb
+++ b/lib/symmetric_encryption/keystore/aws.rb
@@ -75,7 +75,8 @@ module SymmetricEncryption
                                  cipher_name:,
                                  app_name:,
                                  environment:,
-                                 key_path:)
+                                 key_path:,
+                                 **args)
 
         # TODO: Also support generating environment variables instead of files.
 

--- a/lib/symmetric_encryption/keystore/environment.rb
+++ b/lib/symmetric_encryption/keystore/environment.rb
@@ -7,7 +7,7 @@ module SymmetricEncryption
       # Returns [Hash] a new keystore configuration after generating the data key.
       #
       # Increments the supplied version number by 1.
-      def self.generate_data_key(cipher_name:, app_name:, environment:, version: 0, dek: nil)
+      def self.generate_data_key(cipher_name:, app_name:, environment:, version: 0, dek: nil, **args)
         version >= 255 ? (version = 1) : (version += 1)
 
         kek   = SymmetricEncryption::Key.new(cipher_name: cipher_name)

--- a/lib/symmetric_encryption/keystore/file.rb
+++ b/lib/symmetric_encryption/keystore/file.rb
@@ -6,7 +6,7 @@ module SymmetricEncryption
       # Returns [Hash] a new keystore configuration after generating the data key.
       #
       # Increments the supplied version number by 1.
-      def self.generate_data_key(key_path:, cipher_name:, app_name:, environment:, version: 0, dek: nil)
+      def self.generate_data_key(key_path:, cipher_name:, app_name:, environment:, version: 0, dek: nil, **args)
         version >= 255 ? (version = 1) : (version += 1)
 
         dek ||= SymmetricEncryption::Key.new(cipher_name: cipher_name)

--- a/lib/symmetric_encryption/keystore/memory.rb
+++ b/lib/symmetric_encryption/keystore/memory.rb
@@ -12,7 +12,7 @@ module SymmetricEncryption
       # Notes:
       # * For development and testing purposes only!!
       # * Never store the encrypted encryption key in the source code / config file.
-      def self.generate_data_key(cipher_name:, app_name:, environment:, version: 0, dek: nil)
+      def self.generate_data_key(cipher_name:, app_name:, environment:, version: 0, dek: nil, **args)
         version >= 255 ? (version = 1) : (version += 1)
 
         kek   = SymmetricEncryption::Key.new(cipher_name: cipher_name)


### PR DESCRIPTION
Fixed issues where named parameters weren't provided, and in some cases where they were provided, the receiving method wasn't expecting the parameter. Added catch-all `**args` to the keystores so that they could opt-in to desired information and ignore anything else.

### Issue # (if available)

rocketjob/symmetric-encryption#106

### Description of changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
