### PR TITLE
Prevent encrypted attribute corruption when using None-encoder

### DIFF
--- a/lib/symmetric_encryption/encoder.rb
+++ b/lib/symmetric_encryption/encoder.rb
@@ -25,11 +25,11 @@ module SymmetricEncryption
 
     class None
       def encode(binary_string)
-        binary_string
+        binary_string.dup
       end
 
       def decode(encoded_string)
-        encoded_string
+        encoded_string.dup
       end
     end
 

--- a/lib/symmetric_encryption/encoder.rb
+++ b/lib/symmetric_encryption/encoder.rb
@@ -25,11 +25,11 @@ module SymmetricEncryption
 
     class None
       def encode(binary_string)
-        binary_string.dup
+        binary_string&.dup
       end
 
       def decode(encoded_string)
-        encoded_string.dup
+        encoded_string&.dup
       end
     end
 

--- a/lib/symmetric_encryption/generator.rb
+++ b/lib/symmetric_encryption/generator.rb
@@ -24,10 +24,10 @@ module SymmetricEncryption
         # Also updates the encrypted field with the encrypted value
         # Freeze the decrypted field value so that it is not modified directly
         def #{decrypted_name}=(value)
-          v = SymmetricEncryption::Coerce.coerce(value, :#{type})
+          v = SymmetricEncryption::Coerce.coerce(value, :#{type}).freeze
           return if (@#{decrypted_name} == v) && !v.nil? && !(v == '')
-          self.#{encrypted_name} = @stored_#{encrypted_name} = ::SymmetricEncryption.encrypt(v, random_iv: #{random_iv}, compress: #{compress}, type: :#{type})
-          @#{decrypted_name} = v.freeze
+          self.#{encrypted_name} = @stored_#{encrypted_name} = ::SymmetricEncryption.encrypt(v, random_iv: #{random_iv}, compress: #{compress}, type: :#{type}).freeze
+          @#{decrypted_name} = v
         end
 
         # Returns the decrypted value for the encrypted field
@@ -35,7 +35,7 @@ module SymmetricEncryption
         # If this method is not called, then the encrypted value is never decrypted
         def #{decrypted_name}
           if !defined?(@stored_#{encrypted_name}) || (@stored_#{encrypted_name} != self.#{encrypted_name})
-            @#{decrypted_name} = ::SymmetricEncryption.decrypt(self.#{encrypted_name}, type: :#{type}).freeze
+            @#{decrypted_name} = ::SymmetricEncryption.decrypt(self.#{encrypted_name}.freeze, type: :#{type}).freeze
             @stored_#{encrypted_name} = self.#{encrypted_name}
           end
           @#{decrypted_name}

--- a/test/encoder_test.rb
+++ b/test/encoder_test.rb
@@ -46,12 +46,20 @@ class EncoderTest < Minitest::Test
           assert_equal '', @encoder.encode('')
         end
 
+        it 'return a new object when encoding' do
+          assert_not_same @data, @encoder.encode(@data)
+        end
+
         it 'return nil when decoding nil' do
           assert_nil @encoder.decode(nil)
         end
 
         it "return '' when decoding ''" do
           assert_equal '', @encoder.decode('')
+        end
+
+        it 'return a new object when decoding' do
+          assert_not_same @data_encoded, @encoder.decode(@data_encoded)
         end
       end
     end

--- a/test/encoder_test.rb
+++ b/test/encoder_test.rb
@@ -47,7 +47,7 @@ class EncoderTest < Minitest::Test
         end
 
         it 'return a new object when encoding' do
-          assert_not_same @data, @encoder.encode(@data)
+          assert !@data.equal?(@encoder.encode(@data))
         end
 
         it 'return nil when decoding nil' do
@@ -59,7 +59,7 @@ class EncoderTest < Minitest::Test
         end
 
         it 'return a new object when decoding' do
-          assert_not_same @data_encoded, @encoder.decode(@data_encoded)
+          assert !@data_encoded.equal?(@encoder.decode(@data_encoded))
         end
       end
     end


### PR DESCRIPTION
### Issue #108 

### Description of changes

Ensure model attributes cannot be modified in-place. Freeze strings and let the `None`-encoder return a copy of the strings to de/encode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.