### PR TITLE
Fix run_rotate_keys

### DIFF
--- a/lib/symmetric_encryption/cli.rb
+++ b/lib/symmetric_encryption/cli.rb
@@ -231,7 +231,7 @@ module SymmetricEncryption
     end
 
     def run_rotate_keys
-      if keystore && KEYSTORES.include?(keystore)
+      if keystore && !KEYSTORES.include?(keystore)
         puts "Invalid keystore option: #{keystore}, must be one of #{KEYSTORES.join(', ')}"
         exit(-3)
       end


### PR DESCRIPTION
run_rotate_keys was not working as the logic was wrong, and an error was always coming up...

### Issue # (if available)

`symmetric-encryption --rotate-keys` was not working, the logic was inverted...

### Description of changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
