### PR TITLE
Add AWS to list of available keystores

### DIFF
--- a/lib/symmetric_encryption/cli.rb
+++ b/lib/symmetric_encryption/cli.rb
@@ -8,7 +8,7 @@ module SymmetricEncryption
                 :environments, :cipher_name, :rolling_deploy, :rotate_keys, :rotate_kek, :prompt, :show_version,
                 :cleanup_keys, :activate_key, :migrate, :regions
 
-    KEYSTORES = %i[heroku environment file].freeze
+    KEYSTORES = %i[aws heroku environment file].freeze
 
     def self.run!(argv)
       new(argv).run!


### PR DESCRIPTION
### Issue # (if available)
#105 aws is not considered a valid value of `--keystore` in v4.1.2

### Description of changes
Adds aws to `keystores` constant.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
