### PR TITLE
Extract components requirement to a separate 'core' module

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ SymmetricEncryption.decrypt "JqLJOi6dNjWI9kX9lSL1XQ=="
 
 * Externalization of symmetric encryption keys so that they are not in the
   source code, or the source code control system.
-* For maximum security uses randomized keys and initialization vectors extracted 
+* For maximum security uses randomized keys and initialization vectors extracted
   from the entire encryption key space.
 * Option to generate a new initialization vector (IV) with every encrypted value.
 
@@ -54,12 +54,12 @@ SymmetricEncryption.decrypt "JqLJOi6dNjWI9kX9lSL1XQ=="
 * Stream based encryption and decryption so that large files can be read or
   written with encryption.
 * When selected, compress and decompress file streams on the fly.
-* Generate a new randomized key and initialization vector (IV) for every file. 
+* Generate a new randomized key and initialization vector (IV) for every file.
 
 ### Compression
 
 * Transparently compress data prior to encryption.
-* During decryption data is automatically decompressed. 
+* During decryption data is automatically decompressed.
 * Uses Ruby built-in support for OpenSSL and Zlib for high performance and
   maximum portability without introducing any additional dependencies.
 
@@ -78,7 +78,7 @@ Symmetric Encryption v4 introduces an extensive command line interface to:
 * Generate new passwords
 * Generate a new configuration file
 * Perform Key rotation
-  
+
 ## Encrypting Passwords in configuration files
 
 Passwords can be encrypted in any YAML configuration file.
@@ -158,6 +158,20 @@ gem 'symmetric-encryption'
 Install the Gem with bundler
 
     bundle install
+
+### Using without extensions
+
+By default `symmetric-encryption` extends ORMs (ActiveRecord) and loads a Railstie to integrate with Rails configuration. However you may want to disable this behavior and instead use classes provided by Symmetric Encryption and perform configuration by yourself. To do this you should disable automatic require of the gem in your Gemfile:
+
+~~~ruby
+gem 'symmetric-encryption', require: false
+~~~
+
+And then you should manually require Symmetric Encryption library core module which just loads the library classes without any extensions at the place where you use it:
+
+~~~ruby
+require 'symmetric_encryption/core'
+~~~
 
 ## Support
 

--- a/lib/symmetric_encryption.rb
+++ b/lib/symmetric_encryption.rb
@@ -1,32 +1,4 @@
-# Used for compression
-require 'zlib'
-# Used to coerce data types between string and their actual types
-require 'coercible'
-
-require 'symmetric_encryption/version'
-require 'symmetric_encryption/cipher'
-require 'symmetric_encryption/symmetric_encryption'
-require 'symmetric_encryption/exception'
-
-# @formatter:off
-module SymmetricEncryption
-  autoload :Coerce,                 'symmetric_encryption/coerce'
-  autoload :Config,                 'symmetric_encryption/config'
-  autoload :Encoder,                'symmetric_encryption/encoder'
-  autoload :Generator,              'symmetric_encryption/generator'
-  autoload :Header,                 'symmetric_encryption/header'
-  autoload :Key,                    'symmetric_encryption/key'
-  autoload :Reader,                 'symmetric_encryption/reader'
-  autoload :RSAKey,                 'symmetric_encryption/rsa_key'
-  autoload :Writer,                 'symmetric_encryption/writer'
-  autoload :CLI,                    'symmetric_encryption/cli'
-  autoload :Keystore,               'symmetric_encryption/keystore'
-  module Utils
-    autoload :Aws,                  'symmetric_encryption/utils/aws'
-    autoload :ReEncryptFiles,       'symmetric_encryption/utils/re_encrypt_files'
-  end
-end
-# @formatter:on
+require 'symmetric_encryption/core'
 
 # Add extensions. Gems are no longer order dependent.
 begin

--- a/lib/symmetric_encryption/core.rb
+++ b/lib/symmetric_encryption/core.rb
@@ -1,0 +1,29 @@
+# Used for compression
+require 'zlib'
+# Used to coerce data types between string and their actual types
+require 'coercible'
+
+require 'symmetric_encryption/version'
+require 'symmetric_encryption/cipher'
+require 'symmetric_encryption/symmetric_encryption'
+require 'symmetric_encryption/exception'
+
+# @formatter:off
+module SymmetricEncryption
+  autoload :Coerce,                 'symmetric_encryption/coerce'
+  autoload :Config,                 'symmetric_encryption/config'
+  autoload :Encoder,                'symmetric_encryption/encoder'
+  autoload :Generator,              'symmetric_encryption/generator'
+  autoload :Header,                 'symmetric_encryption/header'
+  autoload :Key,                    'symmetric_encryption/key'
+  autoload :Reader,                 'symmetric_encryption/reader'
+  autoload :RSAKey,                 'symmetric_encryption/rsa_key'
+  autoload :Writer,                 'symmetric_encryption/writer'
+  autoload :CLI,                    'symmetric_encryption/cli'
+  autoload :Keystore,               'symmetric_encryption/keystore'
+  module Utils
+    autoload :Aws,                  'symmetric_encryption/utils/aws'
+    autoload :ReEncryptFiles,       'symmetric_encryption/utils/re_encrypt_files'
+  end
+end
+# @formatter:on


### PR DESCRIPTION
### Description of changes

We want to use Symmetric Encryption in our project, however we don't want to load extensions for ActiveRecord because we want to implement these extensions ourselves (using AR Attributes API). Besides we don't want to load the Railtie, we want to perform Cipher/Keystore configuration manually.

To make this possible I extracted the require calls from `lib/symmetric_encryption.rb` to a new file `lib/symmetric_encryption/core.rb`. This way I can require only the things which I really need by adding `require: false` to the gemfile and then requiring `symmetric_encryption/core` in my project.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
