### PR TITLE
Lazily loads ORM adapters to mitigate #110

### DIFF
--- a/lib/symmetric_encryption.rb
+++ b/lib/symmetric_encryption.rb
@@ -7,18 +7,14 @@ begin
 rescue LoadError
 end
 
-begin
-  require 'active_record'
+ActiveSupport.on_load(:active_record) do
   require 'symmetric_encryption/railties/attr_encrypted'
   require 'symmetric_encryption/railties/symmetric_encryption_validator'
 
   ActiveRecord::Base.include(SymmetricEncryption::Railties::AttrEncrypted)
-rescue LoadError
 end
 
-begin
-  require 'mongoid'
+ActiveSupport.on_load(:mongoid) do
   require 'symmetric_encryption/railties/mongoid_encrypted'
   require 'symmetric_encryption/railties/symmetric_encryption_validator'
-rescue LoadError
 end


### PR DESCRIPTION
### Issue # (if available)
See #110.

### Description of changes
Lazily loads ORM adapters instead of explicitly requiring them within lib/symmetric_encryption.rb.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.