### PR TITLE
Fix some documentation issues

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,7 +130,7 @@ chmod -R 0400 ~/.symmetric-encryption
 Specify Heroku as the keystore so that the encrypted encryption keys can be stored in Heroku instead of in files.
 
     symmetric-encryption --generate --keystore heroku --app-name my_app --envs "development,test,production"
-    
+
 ### AWS KMS keystore
 
 Symmetric Encryption can use the [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to hold and manage
@@ -138,10 +138,10 @@ the Key Encrypting Key (Customer Master Key).
 
 This is the most secure keystore that Symmetric Encryption currently supports. By storing the master key
 in AWS KMS it cannot be read or exported, only used to encrypt or decrypt the data encryption keys. The encrypted
-data encryption key is stored locally on the file system since it has been secured by encrypting it with the 
+data encryption key is stored locally on the file system since it has been secured by encrypting it with the
 AWS KMS Customer Master key.
 
-Symmetric Encryption creates a new Customer Master Key in AWS KMS in every AWS Region and for every environment 
+Symmetric Encryption creates a new Customer Master Key in AWS KMS in every AWS Region and for every environment
 so that they can be managed and rotated directly from within the AWS KMS management interface.
 
 #### AWS Dependencies
@@ -154,7 +154,7 @@ Symmetric Encryption. Add the following line to Gemfile when using bundler:
 If not using Bundler, run the following from the command line:
 
     gem install aws-sdk-kms
-    
+
 #### Setting up the AWS Credentials:
 
 In order to create new keys, or to rotate new keys using the AWS KMS, it is necessary to create the necessary
@@ -163,9 +163,9 @@ AWS Credentials.
 It is recommended to use a separate _management_ AWS KMS credential to manage the keys. These credentials should
 be granted access to all KMS operations. See Access Control below for securing runtime privileges by environment.
 
-Follow the AWS instructions for [creating and setting the AWS credentials](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html) 
+Follow the AWS instructions for [creating and setting the AWS credentials](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html)
 
-#### Setting up the AWS Credentials:
+#### Generating new data keys:
 
 Once the AWS _management_ credentials have been created and set, the new keys can now be generated.
 
@@ -196,17 +196,17 @@ in that region.
 The simplest way to set the region is to set the `AWS_REGION` environment variable.
 
     export AWS_REGION=us-west-2
-    
+
 See the AWS documentation for more options in [setting the AWS Region](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html).
 
 #### Access Control
 
-Each environment should have its own credentials and those credentials should be restricted to decrypting using 
-the Customer Master Key (CMK) for that environment only. This prevents different environments from being able 
+Each environment should have its own credentials and those credentials should be restricted to decrypting using
+the Customer Master Key (CMK) for that environment only. This prevents different environments from being able
 to decrypt the data encryption key (DEK) from another environment.
 
-For each key, in each region change the permissions on the key itself so that only that environment's 
-AWS API user can access that key. For example, create a user `rails_release` for the release environment 
+For each key, in each region change the permissions on the key itself so that only that environment's
+AWS API user can access that key. For example, create a user `rails_release` for the release environment
 and limit it to decrypt authorization on the `release` key.
 
 ### Google Cloud Platform KMS

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-### Symmetric Encryption for Ruby Projects using OpenSSL
+## Symmetric Encryption for Ruby Projects using OpenSSL
 
 Any project that wants to meet PCI compliance has to ensure that the data is encrypted
 whilst in flight and at rest. Amongst many other requirements all passwords
@@ -79,7 +79,7 @@ Symmetric Encryption v4 introduces an extensive command line interface to:
 * Generate a new configuration file
 * Perform Key rotation
 
-## Encrypting Passwords in configuration files
+### Encrypting Passwords in configuration files
 
 Passwords can be encrypted in any YAML configuration file.
 
@@ -95,7 +95,7 @@ production:
   password: <%= SymmetricEncryption.try_decrypt "JqLJOi6dNjWI9kX9lSL1XQ==\n" %>
 ~~~
 
-### Notes
+#### Notes
 
 * Use `SymmetricEncryption.try_decrypt` to return nil if it
   fails to decrypt the value, which is essential when the encryption keys differ
@@ -111,7 +111,7 @@ production:
     raise("Environment #{Rails.env} not defined in redis.yml") unless cfg
 ~~~
 
-## Large File Encryption
+### Large File Encryption
 
 Example: Read and decrypt a line at a time from a file
 
@@ -147,7 +147,7 @@ end
 * Ruby v2.1, v2.2, v2.3, v2.4, or higher.
 * JRuby v1.7.23, v9.0.5.0, or higher.
 
-### Installation
+## Installation
 
 Add the following line to Gemfile
 

--- a/lib/symmetric_encryption/railtie.rb
+++ b/lib/symmetric_encryption/railtie.rb
@@ -14,8 +14,8 @@ module SymmetricEncryption #:nodoc:
     #   end
     config.symmetric_encryption = ::SymmetricEncryption
 
-    # Initialize Symmetry. This will look for a symmetry.yml in the config
-    # directory and configure Symmetry appropriately.
+    # Initialize Symmetric Encryption. This will look for a symmetric-encryption.yml in the config
+    # directory and configure Symmetric Encryption appropriately.
     #
     # @example symmetric-encryption.yml
     #


### PR DESCRIPTION
### Description of changes

This PR fixes following fixes in the documentation
- Copy-paste error in the header at `docs/configuration.md`
- Wrong YML name used in the comment at `lib/symmetric_encryption/railtie.rb`
- Inconsistent headings at `docs/index.md`
- Some auto-fixed terminal whitespaces

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
