### PR TITLE
[fix] Update links to Heroku/Standalone docs

### DIFF
--- a/docs/v3_configuration.md
+++ b/docs/v3_configuration.md
@@ -4,9 +4,9 @@ layout: default
 
 ## Rails Configuration with Symmetric Encryption v3:
 
-If deploying to Heroku, see: [Heroku Configuration](heroku.html)
+If deploying to Heroku, see: [Heroku Configuration](heroku.md)
 
-For a standalone environment without Rails, see: [Standalone Configuration](standalone.html)
+For a standalone environment without Rails, see: [Standalone Configuration](standalone.md)
 
 ### Add to Gemfile
 


### PR DESCRIPTION
### Issue 
Broken doco links for Heroku/standalone configuration.

### Description of changes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
