### PR TITLE
Docs: replace "--envs" with "--environments"

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,7 +129,7 @@ chmod -R 0400 ~/.symmetric-encryption
 
 Specify Heroku as the keystore so that the encrypted encryption keys can be stored in Heroku instead of in files.
 
-    symmetric-encryption --generate --keystore heroku --app-name my_app --envs "development,test,production"
+    symmetric-encryption --generate --keystore heroku --app-name my_app --environments "development,test,production"
 
 ### AWS KMS keystore
 


### PR DESCRIPTION
### Description of changes

The Heroku CLI configuration example incorrectly uses an `--envs`, which results in:

```
OptionParser::InvalidOption: invalid option: --envs
```

The correct flag is `--environments`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
