### PR TITLE
Fix Rails 6.0 deprecation message `Module#parent` has been renamed to…

### DIFF
--- a/lib/symmetric_encryption/railtie.rb
+++ b/lib/symmetric_encryption/railtie.rb
@@ -29,7 +29,8 @@ module SymmetricEncryption #:nodoc:
     config.before_configuration do
       # Check if already configured
       unless ::SymmetricEncryption.cipher?
-        app_name    = Rails::Application.subclasses.first.parent.to_s.underscore
+        parent_method = Module.method_defined?(:module_parent) ? 'module_parent' : 'parent'
+        app_name    = Rails::Application.subclasses.first.send(parent_method).to_s.underscore
         env_var     = ENV['SYMMETRIC_ENCRYPTION_CONFIG']
         config_file =
           if env_var


### PR DESCRIPTION
### Purpose

Fix depreciation warnings in Rails 6.0.0
```
DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1.
```

### Description of changes
Checks if Module can receive the new `module_parent` and uses it or falls back to the prior `parent` call.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.