### PR TITLE
Allow the system owner to specify the key owner

### DIFF
--- a/lib/symmetric_encryption/keystore/file.rb
+++ b/lib/symmetric_encryption/keystore/file.rb
@@ -1,3 +1,5 @@
+require 'etc'
+
 module SymmetricEncryption
   module Keystore
     class File
@@ -85,7 +87,11 @@ module SymmetricEncryption
       end
 
       def owned?
-        stat.owned?
+        stat.owned? || custom_owned?
+      end
+
+      def custom_owned?
+        ENV['SYMMETRIC_ENCRYPTION_ALLOWED_FILE_OWNER_USERNAME'] == Etc.getlogin
       end
 
       def stat


### PR DESCRIPTION
Fixes #139

I tried to write a test for this, but cannot reliably change the file ownership.

```ruby
it 'raises an exception when the file is owned by others' do
  FileUtils.chmod 0o777, Dir.glob("#{the_test_path}/*")
  keystore.write('TEST')

  user = nil
  Etc.passwd { |u| break user = u unless Etc.getlogin == u.name }
  username = user.name
  groupname = Etc.getgrgid(user.gid.to_i).name
  
  FileUtils.chown username, groupname, Dir.glob("#{the_test_path}/*")
  FileUtils.chmod 0o600, Dir.glob("#{the_test_path}/*")
  assert_raises { keystore.read }
end
```

causes:

```
  1) Error:
SymmetricEncryption::Keystore::File::#write, #read#test_0003_raises an exception when the file is owned by others:
Errno::EPERM: Operation not permitted @ apply2files - tmp/keystore/file_test/tester.key.1574679581
    /Users/samuel.nissen/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/fileutils.rb:1329:in `chown'
    /Users/samuel.nissen/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/fileutils.rb:1329:in `chown'
    /Users/samuel.nissen/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/fileutils.rb:1046:in `block in chown'
    /Users/samuel.nissen/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/fileutils.rb:1045:in `each'
    /Users/samuel.nissen/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/fileutils.rb:1045:in `chown'
    /Users/samuel.nissen/Development/symmetric-encryption/test/keystore/file_test.rb:106:in `block (3 levels) in <class:FileTest>'
```