### PR TITLE
Rails 7 and ruby32 support

### DIFF
--- a/lib/symmetric_encryption/active_record/attr_encrypted.rb
+++ b/lib/symmetric_encryption/active_record/attr_encrypted.rb
@@ -63,7 +63,7 @@ module SymmetricEncryption
               type:      type,
               compress:  compress
             )
-            encrypted_attributes[attribute.to_sym] = "encrypted_#{attribute}".to_sym
+            symmetric_encrypted_attributes[attribute.to_sym] = "encrypted_#{attribute}".to_sym
           end
         end
 
@@ -76,21 +76,21 @@ module SymmetricEncryption
         #     attr_encrypted :email
         #   end
         #
-        #   User.encrypted_attributes  =>  { email: encrypted_email }
-        def encrypted_attributes
-          @encrypted_attributes ||= superclass.respond_to?(:encrypted_attributes) ? superclass.encrypted_attributes.dup : {}
+        #   User.symmetric_encrypted_attributes  =>  { email: encrypted_email }
+        def symmetric_encrypted_attributes
+          @symmetric_encrypted_attributes ||= superclass.respond_to?(:symmetric_encrypted_attributes) ? superclass.symmetric_encrypted_attributes.dup : {}
         end
 
         # Return the name of all encrypted virtual attributes as an Array of symbols
         # Example: [:email, :password]
         def encrypted_keys
-          @encrypted_keys ||= encrypted_attributes.keys
+          @encrypted_keys ||= symmetric_encrypted_attributes.keys
         end
 
         # Return the name of all encrypted columns as an Array of symbols
         # Example: [:encrypted_email, :encrypted_password]
         def encrypted_columns
-          @encrypted_columns ||= encrypted_attributes.values
+          @encrypted_columns ||= symmetric_encrypted_attributes.values
         end
 
         # Returns whether an attribute has been configured to be encrypted

--- a/lib/symmetric_encryption/config.rb
+++ b/lib/symmetric_encryption/config.rb
@@ -27,7 +27,7 @@ module SymmetricEncryption
 
     # Reads the entire configuration for all environments from the supplied file name.
     def self.read_file(file_name)
-      config = YAML.load(ERB.new(File.new(file_name).read).result)
+      config = YAML.load(ERB.new(File.new(file_name).read).result, aliases: true)
       config = deep_symbolize_keys(config)
       config.each_pair { |_env, cfg| SymmetricEncryption::Config.send(:migrate_old_formats!, cfg) }
       config
@@ -75,7 +75,7 @@ module SymmetricEncryption
         begin
           raise(ConfigError, "Cannot find config file: #{file_name}") unless File.exist?(file_name)
 
-          env_config = YAML.load(ERB.new(File.new(file_name).read).result)[env]
+          env_config = YAML.load(ERB.new(File.new(file_name).read).result, aliases: true)[env]
           raise(ConfigError, "Cannot find environment: #{env} in config file: #{file_name}") unless env_config
 
           env_config = self.class.send(:deep_symbolize_keys, env_config)


### PR DESCRIPTION
### Issue # (if available)

On Psych 4, with ruby 3.2.2, we need to enable `alias` when loading YAML file.

### Description of changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
