### PR TITLE
Allow disabling keystore file checks

### DIFF
--- a/lib/symmetric_encryption/keystore/file.rb
+++ b/lib/symmetric_encryption/keystore/file.rb
@@ -52,12 +52,12 @@ module SymmetricEncryption
           raise(SymmetricEncryption::ConfigError,
                 "Symmetric Encryption key file: '#{file_name}' not found")
         end
-        unless correct_permissions?
+        unless SymmetricEncryption.skip_keystore_file_permissions? || correct_permissions?
           raise(SymmetricEncryption::ConfigError,
                 "Symmetric Encryption key file '#{file_name}' has the wrong " \
                 "permissions: #{::File.stat(file_name).mode.to_s(8)}. Expected 100600 or 100400.")
         end
-        unless owned?
+        unless SymmetricEncryption.skip_keystore_file_owner? || owned?
           raise(SymmetricEncryption::ConfigError,
                 "Symmetric Encryption key file '#{file_name}' has the wrong " \
                 "owner (#{stat.uid}) or group (#{stat.gid}). " \

--- a/lib/symmetric_encryption/symmetric_encryption.rb
+++ b/lib/symmetric_encryption/symmetric_encryption.rb
@@ -300,6 +300,20 @@ module SymmetricEncryption
     SecureRandom.urlsafe_base64(size)
   end
 
+  class << self
+    attr_accessor :skip_keystore_file_permissions, :skip_keystore_file_owner
+    alias_method :skip_keystore_file_permissions?, :skip_keystore_file_permissions
+    alias_method :skip_keystore_file_owner?, :skip_keystore_file_owner
+  end
+
+  def self.skip_keystore_file_permissions!
+    @skip_keystore_file_permissions = true
+  end
+
+  def self.skip_keystore_file_owner!
+    @skip_keystore_file_owner = true
+  end
+
   BINARY_ENCODING = Encoding.find("binary")
   UTF8_ENCODING   = Encoding.find("UTF-8")
 
@@ -308,4 +322,6 @@ module SymmetricEncryption
   @secondary_ciphers = []
   @select_cipher     = nil
   @randomize_iv      = false
+  @skip_keystore_file_permissions = false
+  @skip_keystore_file_owner = false
 end

--- a/test/keystore/file_test.rb
+++ b/test/keystore/file_test.rb
@@ -79,6 +79,7 @@ module SymmetricEncryption
 
         after do
           FileUtils.chmod 0o600, Dir.glob("#{the_test_path}/*")
+          SymmetricEncryption.skip_keystore_file_permissions = false
         end
 
         it "stores the key" do
@@ -90,6 +91,13 @@ module SymmetricEncryption
           keystore.write("TEST")
           FileUtils.chmod 0o666, Dir.glob("#{the_test_path}/*")
           assert_raises { keystore.read }
+        end
+
+        it "does not raise an exception when the permission validation is disabled" do
+          keystore.write("TEST")
+          FileUtils.chmod 0o666, Dir.glob("#{the_test_path}/*")
+          SymmetricEncryption.skip_keystore_file_permissions!
+          assert_equal "TEST", keystore.read
         end
       end
     end


### PR DESCRIPTION
This change allow the gem users to disable the owner and permissions validation on the key file.

Solves: #139 #170

### Issue # (if available)


### Description of changes

This commits implements and extends the idea of @reidmorrison in this comment https://github.com/reidmorrison/symmetric-encryption/pull/140#issuecomment-1003435354

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
