### PR TITLE
Add frozen string literal support for Ruby 3.4 compatibility

### DIFF
--- a/lib/symmetric-encryption.rb
+++ b/lib/symmetric-encryption.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "symmetric_encryption"

--- a/lib/symmetric_encryption.rb
+++ b/lib/symmetric_encryption.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "symmetric_encryption/core"
 
 # Add extensions. Gems are no longer order dependent.

--- a/lib/symmetric_encryption/active_record/attr_encrypted.rb
+++ b/lib/symmetric_encryption/active_record/attr_encrypted.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   module ActiveRecord
     module AttrEncrypted

--- a/lib/symmetric_encryption/active_record/encrypted_attribute.rb
+++ b/lib/symmetric_encryption/active_record/encrypted_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   module ActiveRecord
     class EncryptedAttribute < ::ActiveModel::Type::String

--- a/lib/symmetric_encryption/cipher.rb
+++ b/lib/symmetric_encryption/cipher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "openssl"
 module SymmetricEncryption
   # Hold all information related to encryption keys

--- a/lib/symmetric_encryption/cli.rb
+++ b/lib/symmetric_encryption/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "optparse"
 require "fileutils"
 module SymmetricEncryption

--- a/lib/symmetric_encryption/coerce.rb
+++ b/lib/symmetric_encryption/coerce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   # For coercing data types to from strings
   module Coerce

--- a/lib/symmetric_encryption/config.rb
+++ b/lib/symmetric_encryption/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "erb"
 require "yaml"
 module SymmetricEncryption

--- a/lib/symmetric_encryption/core.rb
+++ b/lib/symmetric_encryption/core.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Used for compression
 require "zlib"
 # Used to coerce data types between string and their actual types

--- a/lib/symmetric_encryption/encoder.rb
+++ b/lib/symmetric_encryption/encoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   module Encoder
     def self.[](encoding)

--- a/lib/symmetric_encryption/exception.rb
+++ b/lib/symmetric_encryption/exception.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   # Exceptions created by SymmetricEncryption
   class Error < StandardError

--- a/lib/symmetric_encryption/generator.rb
+++ b/lib/symmetric_encryption/generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   module Generator
     # Common internal method for generating accessors for decrypted accessors

--- a/lib/symmetric_encryption/header.rb
+++ b/lib/symmetric_encryption/header.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   # Defines the Header Structure returned when parsing the header.
   #
@@ -8,7 +10,7 @@ module SymmetricEncryption
   class Header
     # Encrypted data includes this header prior to encoding when
     # `always_add_header` is true.
-    MAGIC_HEADER      = "@EnC".force_encoding(SymmetricEncryption::BINARY_ENCODING)
+    MAGIC_HEADER      = (+"@EnC").force_encoding(SymmetricEncryption::BINARY_ENCODING)
     MAGIC_HEADER_SIZE = MAGIC_HEADER.size
 
     # [true|false] Whether to compress the data before encryption.

--- a/lib/symmetric_encryption/key.rb
+++ b/lib/symmetric_encryption/key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The key, iv and encrypted data are handled in their raw form, with no encoding.
 module SymmetricEncryption
   class Key

--- a/lib/symmetric_encryption/keystore.rb
+++ b/lib/symmetric_encryption/keystore.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   # Encryption keys are secured in Keystores
   module Keystore

--- a/lib/symmetric_encryption/keystore/aws.rb
+++ b/lib/symmetric_encryption/keystore/aws.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "aws-sdk-kms"
 module SymmetricEncryption
   module Keystore

--- a/lib/symmetric_encryption/keystore/environment.rb
+++ b/lib/symmetric_encryption/keystore/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   module Keystore
     # Store the encrypted encryption key in an environment variable

--- a/lib/symmetric_encryption/keystore/file.rb
+++ b/lib/symmetric_encryption/keystore/file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   module Keystore
     class File

--- a/lib/symmetric_encryption/keystore/gcp.rb
+++ b/lib/symmetric_encryption/keystore/gcp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "google/cloud/kms/v1"
 
 module SymmetricEncryption

--- a/lib/symmetric_encryption/keystore/heroku.rb
+++ b/lib/symmetric_encryption/keystore/heroku.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   module Keystore
     # Heroku uses environment variables too.

--- a/lib/symmetric_encryption/keystore/memory.rb
+++ b/lib/symmetric_encryption/keystore/memory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   module Keystore
     # In Memory Keystore usually used for testing purposes

--- a/lib/symmetric_encryption/railtie.rb
+++ b/lib/symmetric_encryption/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption # :nodoc:
   class Railtie < Rails::Railtie # :nodoc:
     # Exposes Symmetric Encryption's configuration to the Rails application configuration.

--- a/lib/symmetric_encryption/railties/mongoid_encrypted.rb
+++ b/lib/symmetric_encryption/railties/mongoid_encrypted.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "mongoid"
 # Add :encrypted option for Mongoid models
 #

--- a/lib/symmetric_encryption/railties/symmetric_encryption_validator.rb
+++ b/lib/symmetric_encryption/railties/symmetric_encryption_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add an ActiveModel Validator
 #
 # Example:

--- a/lib/symmetric_encryption/reader.rb
+++ b/lib/symmetric_encryption/reader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "openssl"
 
 module SymmetricEncryption
@@ -185,7 +187,7 @@ module SymmetricEncryption
     # At end of file, it returns nil if no more data is available, or the last
     # remaining bytes
     def read(length = nil, outbuf = nil)
-      data             = outbuf.nil? ? "" : outbuf.clear
+      data             = outbuf.nil? ? +"" : outbuf.clear
       remaining_length = length
 
       until remaining_length&.zero? || eof?

--- a/lib/symmetric_encryption/rsa_key.rb
+++ b/lib/symmetric_encryption/rsa_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "openssl"
 module SymmetricEncryption
   # DEPRECATED - Internal use only

--- a/lib/symmetric_encryption/symmetric_encryption.rb
+++ b/lib/symmetric_encryption/symmetric_encryption.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "base64"
 require "openssl"
 require "zlib"

--- a/lib/symmetric_encryption/utils/aws.rb
+++ b/lib/symmetric_encryption/utils/aws.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "base64"
 require "aws-sdk-kms"
 module SymmetricEncryption

--- a/lib/symmetric_encryption/utils/files.rb
+++ b/lib/symmetric_encryption/utils/files.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   module Utils
     module Files

--- a/lib/symmetric_encryption/utils/re_encrypt_files.rb
+++ b/lib/symmetric_encryption/utils/re_encrypt_files.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Used for re-encrypting encrypted passwords stored in configuration files.
 #
 # Search for any encrypted value and re-encrypt it using the latest encryption key.

--- a/lib/symmetric_encryption/version.rb
+++ b/lib/symmetric_encryption/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SymmetricEncryption
   VERSION = "4.6.0".freeze
 end

--- a/lib/symmetric_encryption/writer.rb
+++ b/lib/symmetric_encryption/writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "openssl"
 
 module SymmetricEncryption

--- a/test/active_record/encrypted_attribute_test.rb
+++ b/test/active_record/encrypted_attribute_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 ActiveRecord::Base.configurations = YAML.safe_load(ERB.new(File.read("test/config/database.yml")).result)

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 if ActiveRecord.version <= Gem::Version.new("7.0.0")

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 # Tests for SymmetricEncryption::Cipher
@@ -63,13 +65,13 @@ class CipherTest < Minitest::Test
                     no_header: "c9378b8ec1d36bcca4a0ef792b42909a"
                   },
                   none:          {
-                    header:    "@EnC\x00\x00\xC97\x8B\x8E\xC1\xD3k\xCC\xA4\xA0\xEFy+B\x90\x9A",
-                    no_header: "\xC97\x8B\x8E\xC1\xD3k\xCC\xA4\xA0\xEFy+B\x90\x9A"
+                    header:    +"@EnC\x00\x00\xC97\x8B\x8E\xC1\xD3k\xCC\xA4\xA0\xEFy+B\x90\x9A",
+                    no_header: +"\xC97\x8B\x8E\xC1\xD3k\xCC\xA4\xA0\xEFy+B\x90\x9A"
                   }
                 }
               }
 
-              @non_utf8 = "\xc2".force_encoding("binary")
+              @non_utf8 = (+"\xc2").force_encoding("binary")
               @cipher   = SymmetricEncryption::Cipher.new(
                 key:               "ABCDEF1234567890",
                 iv:                "ABCDEF1234567890",
@@ -145,7 +147,7 @@ class CipherTest < Minitest::Test
           )
           @social_security_number = "987654321"
 
-          @social_security_number_encrypted = "A\335*\314\336\250V\340\023%\000S\177\305\372\266"
+          @social_security_number_encrypted = +"A\335*\314\336\250V\340\023%\000S\177\305\372\266"
           @social_security_number_encrypted.force_encoding("binary")
 
           @sample_data = [

--- a/test/encoder_test.rb
+++ b/test/encoder_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 # Unit Test for SymmetricEncryption
@@ -22,7 +24,7 @@ class EncoderTest < Minitest::Test
               @data
             end
           @encoder      = SymmetricEncryption::Encoder[encoding]
-          @non_utf8     = "\xc2".force_encoding("binary")
+          @non_utf8     = (+"\xc2").force_encoding("binary")
         end
 
         it "correctly encodes" do

--- a/test/header_test.rb
+++ b/test/header_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class CipherTest < Minitest::Test
@@ -42,7 +44,7 @@ class CipherTest < Minitest::Test
       end
 
       it "does not have a header" do
-        refute SymmetricEncryption::Header.present?(clear_value)
+        refute SymmetricEncryption::Header.present?(+clear_value)
       end
 
       it "does not have a header when nil" do
@@ -110,7 +112,7 @@ class CipherTest < Minitest::Test
 
       it "unencrypted string" do
         header = SymmetricEncryption::Header.new
-        assert_equal 0, header.parse("hello there")
+        assert_equal 0, header.parse(+"hello there")
       end
 
       it "encrypted string" do
@@ -153,7 +155,7 @@ class CipherTest < Minitest::Test
 
       it "unencrypted string" do
         header = SymmetricEncryption::Header.new
-        assert_nil header.parse!("hello there")
+        assert_nil header.parse!(+"hello there")
       end
 
       it "encrypted string" do

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 class KeyTest < Minitest::Test
@@ -23,7 +25,7 @@ class KeyTest < Minitest::Test
     end
 
     let :encrypted_ssn do
-      essn = "cR\x9C,\x91\xA4{\b`\x9Fls\xA4\f\xD1\xBF"
+      essn = +"cR\x9C,\x91\xA4{\b`\x9Fls\xA4\f\xD1\xBF"
       essn.force_encoding("binary")
       essn
     end
@@ -44,7 +46,7 @@ class KeyTest < Minitest::Test
 
     describe "decrypt" do
       it "empty string" do
-        assert_equal "", key.decrypt("")
+        assert_equal "", key.decrypt(+"")
       end
 
       it "nil" do

--- a/test/keystore/aws_test.rb
+++ b/test/keystore/aws_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require "stringio"
 

--- a/test/keystore/environment_test.rb
+++ b/test/keystore/environment_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require "stringio"
 

--- a/test/keystore/file_test.rb
+++ b/test/keystore/file_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require "stringio"
 require "fileutils"

--- a/test/keystore/gcp_test.rb
+++ b/test/keystore/gcp_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 module SymmetricEncryption

--- a/test/keystore/heroku_test.rb
+++ b/test/keystore/heroku_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require "stringio"
 

--- a/test/keystore_test.rb
+++ b/test/keystore_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 module SymmetricEncryption

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "mongoid"
   require_relative "test_helper"

--- a/test/reader_test.rb
+++ b/test/reader_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 require "stringio"
 
@@ -11,7 +13,7 @@ class ReaderTest < Minitest::Test
         "Keep this secret\n",
         "And keep going even further and further..."
       ]
-      @data_str = @data.inject("") { |sum, str| sum << str }
+      @data_str = @data.inject(+"") { |sum, str| sum << str }
       @data_len = @data_str.length
       # Use Cipher 0 since it does not always include a header
       @cipher = SymmetricEncryption.cipher(0)
@@ -188,7 +190,7 @@ class ReaderTest < Minitest::Test
             # Not supported with compressed files
             if file.is_a?(SymmetricEncryption::Reader)
               eof           = file.eof?
-              output_buffer = "buffer"
+              output_buffer = +"buffer"
               data          = file.read(4096, output_buffer)
               file.close
 

--- a/test/symmetric_encryption_test.rb
+++ b/test/symmetric_encryption_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 # Unit Test for SymmetricEncryption
@@ -59,11 +61,11 @@ class SymmetricEncryptionTest < Minitest::Test
             when :base16
               "40456e4302004bef17d4d46ba9d7c4210c851d53ee54"
             when :none
-              "@EnC\x02\x00K\xEF\x17\xD4\xD4k\xA9\xD7\xC4!\f\x85\x1DS\xEET".force_encoding(Encoding.find("binary"))
+              (+"@EnC\x02\x00K\xEF\x17\xD4\xD4k\xA9\xD7\xC4!\f\x85\x1DS\xEET").force_encoding(Encoding.find("binary"))
             else
               raise "Add test for encoding: #{encoding}"
             end
-          @non_utf8                           = "\xc2".force_encoding("binary")
+          @non_utf8                           = (+"\xc2").force_encoding("binary")
           @encoding                           = SymmetricEncryption.cipher.encoding
           SymmetricEncryption.cipher.encoding = encoding
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/../lib"
 
 require "yaml"

--- a/test/utils/aws_test.rb
+++ b/test/utils/aws_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 require "stringio"
 

--- a/test/writer_test.rb
+++ b/test/writer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 require "stringio"
 
@@ -11,7 +13,7 @@ class WriterTest < Minitest::Test
         "Keep this secret\n",
         "And keep going even further and further..."
       ]
-      @data_str = @data.inject("") { |sum, str| sum << str }
+      @data_str = @data.inject(+"") { |sum, str| sum << str }
       @data_len = @data_str.length
       @file_name = "._test"
       @source_file_name = "._source_test"


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

I encountered the following warning message in my application with Ruby 3.4.7:

```
/opt/bundle-cache/ruby/3.4.0/gems/symmetric-encryption-4.6.0/lib/symmetric_encryption/header.rb:11: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

The reason for this warning is that Ruby 3.4 has begun to issue warnings for string mutations.

ref:
> String literals in files without a frozen_string_literal comment now emit a deprecation warning when they are mutated. These warnings can be enabled with -W:deprecated or by setting Warning[:deprecated] = true. To disable this change, you can run Ruby with the --disable-frozen-string-literal command line argument.
>
> https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/

This pull request introduces support for frozen string literals as follows:

- Add `# frozen_string_literal: true` to all Ruby files
- Fix string mutations to ensure compatibility with frozen strings

This change improves memory efficiency and performance by making all string literals immutable by default, aligning with modern Ruby standards.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
